### PR TITLE
Allow users to provide their own cert and key

### DIFF
--- a/rh-hashi/group_vars/all.yml.example
+++ b/rh-hashi/group_vars/all.yml.example
@@ -1,11 +1,15 @@
 ---
 # Override these role variables to attach a RHEL subscription to the Vault RHEL server
-vault_provision_redhat_subscription: true
-vault_provision_redhat_username: user@example.com
-vault_provision_redhat_password: CHANGEME
+#vault_provision_redhat_subscription: true
+#vault_provision_redhat_username: user@example.com
+#vault_provision_redhat_password: CHANGEME
 
 # Override this role variable to point to your local Vault license file
-vault_install_vault_license_file: /tmp/vault.hclic
+#vault_install_vault_license_file: /tmp/vault.hclic
+
+# Override these role variables to point to user-provided cert/key files
+#vault_install_tls_cert: /path/to/cert.pem
+#vault_install_tls_key: /path/to/key.pem
 
 terraform:
   license: <terraform license key>.hclic

--- a/rh-hashi/install-hashi-vault.yml
+++ b/rh-hashi/install-hashi-vault.yml
@@ -31,6 +31,14 @@
     - name: Configure vault
       block:
 
+        - name: Set Vault FQDN fact
+          ansible.builtin.set_fact:
+            _vault_fqdn: "{{ vault_fqdn | default(inventory_hostname) }}"
+
+        - name: Set Vault URL fact
+          ansible.builtin.set_fact:
+            _vault_url: https://{{ _vault_fqdn }}:{{ vault_install_api_port | default('8200') }}
+
         - name: Create storage directories
           become: true
           ansible.builtin.file:
@@ -44,6 +52,9 @@
         - name: Check to see if vault is already initialized
           ansible.builtin.command:
             cmd: vault status -format=json
+          environment:
+            VAULT_ADDR: "{{ _vault_url }}"
+            VAULT_SKIP_VERIFY: "{{ vault_validate_certs | default(false) | ternary('false', 'true') }}"
           register: vault_status_result
           ignore_errors: true
           changed_when: false
@@ -57,20 +68,12 @@
             var: vault_status_parsed
           when: debug | default(false)
 
-        - name: Set Vault FQDN fact
-          ansible.builtin.set_fact:
-            _vault_fqdn: "{{ vault_fqdn | default(inventory_hostname) }}"
-
-        - name: Set Vault URL fact
-          ansible.builtin.set_fact:
-            _vault_url: https://{{ _vault_fqdn }}:{{ vault_install_api_port | default('8200') }}
-
         - name: Initialize Vault operator
           ansible.builtin.command:
             cmd: "vault operator init -key-shares {{ vault.unseal.key_count }} -key-threshold {{ vault.unseal.threshold }} -format json"
           environment:
             VAULT_ADDR: "{{ _vault_url }}"
-            VAULT_SKIP_VERIFY: "true"
+            VAULT_SKIP_VERIFY: "{{ vault_validate_certs | default(false) | ternary('false', 'true') }}"
           register: vault_init_results
           when: not vault_status_parsed.initialized
 
@@ -137,7 +140,7 @@
             status_code: 200
             body:
               key: "{{ item }}"
-            validate_certs: false
+            validate_certs: "{{ vault_validate_certs | default(false) }}"
           loop: "{{ unseal_keys_result.stdout_lines }}"
           register: unseal_api_result
 
@@ -146,7 +149,7 @@
             url: "{{ _vault_url }}"
             auth_method: token
             token: "{{ root_token }}"
-            validate_certs: false
+            validate_certs: "{{ vault_validate_certs | default(false) }}"
           register: login_data
 
         - name: Debug login data

--- a/rh-hashi/roles/vault_install/defaults/main.yml
+++ b/rh-hashi/roles/vault_install/defaults/main.yml
@@ -5,16 +5,20 @@ vault_install_vault_package_name: vault-enterprise
 
 vault_install_vault_license_file: /tmp/vault.hclic
 
-vault_install_vault_key: /etc/vault.d/vault-key.pem
-vault_install_vault_certificate: /etc/vault.d/vault-cert.pem
-vault_install_vault_ca_cert: /etc/pki/tls/certs/hashivault-ca-certificate.pem
-vault_install_vault_ca_key: /etc/pki/tls/private/hashivault-ca-certificate.key
+vault_install_tls_cert: ''
+vault_install_tls_key: ''
+vault_install_tls_cert_path: /etc/vault.d/vault-cert.pem
+vault_install_tls_key_path: /etc/vault.d/vault-key.pem
 vault_install_cert_org: Red Hat
 vault_install_cert_ou: Demo
 vault_install_cert_state: North Carolina
 vault_install_cert_locality: Raleigh
 
+vault_install_api_fqdn: "{{ inventory_hostname }}"
 vault_install_api_addr: 0.0.0.0
 vault_install_api_port: 8200
+vault_install_cluster_fqdn: localhost
 vault_install_cluster_addr: 127.0.0.1
 vault_install_cluster_port: 8201
+
+...

--- a/rh-hashi/roles/vault_install/tasks/main.yml
+++ b/rh-hashi/roles/vault_install/tasks/main.yml
@@ -43,55 +43,68 @@
         group: vault
         mode: '0640'
 
-    - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
-      community.crypto.openssl_privatekey:
-        path: "{{ vault_install_vault_key }}"
-        owner: vault
-        group: vault
-        mode: '0640'
+    - name: Install user-defined Vault certificate
+      when: vault_install_tls_cert
+      block:
+        - name: Check if key is provided with certificate
+          ansible.builtin.assert:
+            that:
+              - vault_install_tls_key
+            fail_msg: "Variable 'vault_install_tls_key' must be set when 'vault_install_tls_cert' is set"
 
-    - name: Check whether CA certificate exists
-      ansible.builtin.stat:
-        path: "{{ vault_install_vault_ca_cert }}"
-      register: certificate_exists
+        - name: Copy Vault certificate to required path
+          ansible.builtin.copy:
+            src: "{{ vault_install_tls_cert }}"
+            dest: "{{ vault_install_tls_cert_path }}"
+            owner: vault
+            group: vault
+            mode: '0640'
 
-    - name: Read existing CA certificate if exists
-      # TODO what if it doesn't?  should the vault_openssl_ca role move here?
-      ansible.builtin.slurp:
-        src: "{{ vault_install_vault_ca_cert }}"
-      when: certificate_exists.stat.exists
-      register: certificate
+        - name: Copy Vault certificate to required path
+          ansible.builtin.copy:
+            src: "{{ vault_install_tls_key }}"
+            dest: "{{ vault_install_tls_key_path }}"
+            owner: vault
+            group: vault
+            mode: '0640'
 
-    - name: Generate a new certificate signing request for vault
-      community.crypto.openssl_csr_pipe:
-        privatekey_path: "{{ vault_install_vault_key }}"
-        common_name: "{{ inventory_hostname }}"
-        organization_name: "{{ vault_install_cert_org }}"
-        organizational_unit_name: "{{ vault_install_cert_ou }}"
-        state_or_province_name: "{{ vault_install_cert_state }}"
-        locality_name: "{{ vault_install_cert_locality }}"
-        subject_alt_name:
-          - "DNS:localhost"
-          - "DNS:{{ ansible_fqdn }}"
-          - "IP:127.0.0.1"
-          - "IP:{{ ansible_default_ipv4.address }}"
-      register: r_vault_csr
+    - name: Generate Vault self-signed certificate
+      when: not vault_install_tls_cert
+      block:
+        - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
+          community.crypto.openssl_privatekey:
+            path: "{{ vault_install_tls_key_path }}"
+            owner: vault
+            group: vault
+            mode: '0640'
 
-    # TODO generate with "provider: selfsigned" to decouple from vault CA,
-    # and eventually allow user-provided cert/key
-    - name: Sign ssl certificate and key for vault
-      community.crypto.x509_certificate:
-        path: "{{ vault_install_vault_certificate }}"
-        privatekey_path: "{{ vault_install_vault_key }}"
-        csr_content: "{{ r_vault_csr.csr }}"
-        provider: ownca
-        ownca_path: "{{ vault_install_vault_ca_cert }}"
-        ownca_privatekey_path: "{{ vault_install_vault_ca_key }}"
-        ownca_not_after: +365d  # valid for one year
-        ownca_not_before: "-1d"  # valid since yesterday
-        owner: vault
-        group: vault
-        mode: '0640'
+        - name: Generate a new certificate signing request for vault
+          community.crypto.openssl_csr_pipe:
+            privatekey_path: "{{ vault_install_tls_key_path }}"
+            common_name: "{{ inventory_hostname }}"
+            organization_name: "{{ vault_install_cert_org }}"
+            organizational_unit_name: "{{ vault_install_cert_ou }}"
+            state_or_province_name: "{{ vault_install_cert_state }}"
+            locality_name: "{{ vault_install_cert_locality }}"
+            subject_alt_name:
+              - "DNS:localhost"
+              - "DNS:{{ ansible_fqdn }}"
+              - "DNS:{{ inventory_hostname }}"
+              - "IP:127.0.0.1"
+              - "IP:{{ ansible_default_ipv4.address }}"
+          register: r_vault_csr
+
+        - name: Sign ssl certificate and key for vault
+          community.crypto.x509_certificate:
+            path: "{{ vault_install_tls_cert_path }}"
+            privatekey_path: "{{ vault_install_tls_key_path }}"
+            csr_content: "{{ r_vault_csr.csr }}"
+            provider: selfsigned
+            selfsigned_not_after: +365d  # valid for one year
+            selfsigned_not_before: "-1d"  # valid since yesterday
+            owner: vault
+            group: vault
+            mode: '0640'
 
     - name: Start and enable vault service
       ansible.builtin.service:

--- a/rh-hashi/roles/vault_install/templates/vault.hcl.j2
+++ b/rh-hashi/roles/vault_install/templates/vault.hcl.j2
@@ -1,18 +1,18 @@
-api_addr                = "https://{{ vault_install_api_addr }}:{{ vault_install_api_port }}"
-cluster_addr            = "https://{{ vault_install_cluster_addr }}:{{ vault_install_cluster_port }}"
+api_addr                = "https://{{ vault_install_api_fqdn }}:{{ vault_install_api_port }}"
+cluster_addr            = "https://{{ vault_install_cluster_fqdn }}:{{ vault_install_cluster_port }}"
 cluster_name            = "aap-vault-cluster"
 disable_mlock           = true
 ui                      = true
 
 listener "tcp" {
-address       = "{{ vault_install_api_addr }}:{{ vault_install_api_port }}"
-tls_cert_file = "/etc/vault.d/vault-cert.pem"
-tls_key_file  = "/etc/vault.d/vault-key.pem"
+  address       = "{{ vault_install_api_addr }}:{{ vault_install_api_port }}"
+  tls_cert_file = "/etc/vault.d/vault-cert.pem"
+  tls_key_file  = "/etc/vault.d/vault-key.pem"
 }
 
 backend "raft" {
-path    = "/opt/vault/data"
-node_id = "aap-hashi-vault"
+  path    = "/opt/vault/data"
+  node_id = "aap-hashi-vault"
 }
 
 # Enterprise license_path


### PR DESCRIPTION
* Install files defined in vault_install_tls_cert and vault_install_tls_key when defined
* Generate self-signed cert and key when the variables are not defined
* No longer signs self-signed cert with the self-signed CA created in the vault_openssl_ca role
* added vault_install_api_fqdn variable to vault_install role, separate from the vault_install_api_addr variable for the listener config
* Added inventory_hostname as SAN to the Vault self-signed certificate