### PR TITLE
Updated aap_* roles with variable defaults

### DIFF
--- a/rh-hashi/roles/aap_install/defaults/main.yml
+++ b/rh-hashi/roles/aap_install/defaults/main.yml
@@ -9,13 +9,13 @@ aap_install_local_cert_dir: /tmp/aap-certs
 aap_install_cert_dir: "{{ aap_install_aap_user_dir }}/certs"
 
 aap_install_installer_bundle: /tmp/ansible-automation-platform-containerized-setup-bundle-2.5-11.1-x86_64.tar.gz
-aap_install_installer_dir: "{{ aap_install_installer_bundle | basename | regex_replace('\\.tar.gz$', '') }}"
+aap_install_installer_dir: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_bundle | basename | regex_replace('\\.tar.gz$', '') }}"
 
 # installation inventory variable overrides
 aap_install_common_password: CHANGEME
 aap_install_provide_certs: false
-aap_install_common_cert: "{{ aap_install_cert_dir }}/certs/aap-common.crt"
-aap_install_common_key: "{{ aap_install_cert_dir }}/certs/aap-common.key"
-aap_install_custom_ca_cert: "{{ aap_install_cert_dir }}/certs/custom-ca.crt"
+aap_install_common_cert: "{{ aap_install_cert_dir }}/aap-common.crt"
+aap_install_common_key: "{{ aap_install_cert_dir }}/aap-common.key"
+aap_install_custom_ca_cert: "{{ aap_install_cert_dir }}/custom-ca.crt"
 
 ...

--- a/rh-hashi/roles/aap_install/defaults/main.yml
+++ b/rh-hashi/roles/aap_install/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+aap_install_aap_group: aap
+aap_install_aap_user: aap
+aap_install_aap_user_dir: /home/{{ aap_install_aap_user }}
+
+# Install user-provided certs
+aap_install_provide_certs: false
+aap_install_local_cert_dir: /tmp/aap-certs
+aap_install_cert_dir: "{{ aap_install_aap_user_dir }}/certs"
+
+aap_install_installer_bundle: /tmp/ansible-automation-platform-containerized-setup-bundle-2.5-11.1-x86_64.tar.gz
+aap_install_installer_dir: "{{ aap_install_installer_bundle | basename | regex_replace('\\.tar.gz$', '') }}"
+
+# installation inventory variable overrides
+aap_install_common_password: CHANGEME
+aap_install_provide_certs: false
+aap_install_common_cert: "{{ aap_install_cert_dir }}/certs/aap-common.crt"
+aap_install_common_key: "{{ aap_install_cert_dir }}/certs/aap-common.key"
+aap_install_custom_ca_cert: "{{ aap_install_cert_dir }}/certs/custom-ca.crt"
+
+...

--- a/rh-hashi/roles/aap_install/tasks/main.yml
+++ b/rh-hashi/roles/aap_install/tasks/main.yml
@@ -56,12 +56,12 @@
         src: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_bundle | basename }}"
         dest: "{{ aap_install_aap_user_dir }}"
         remote_src: true
-        creates: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_dir }}"
+        creates: "{{ aap_install_installer_dir }}"
 
     - name: Copy the templatized inventory to the created directory
       ansible.builtin.template:
         src: inventory-growth.j2
-        dest: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_dir }}/inventory"
+        dest: "{{ aap_install_installer_dir }}/inventory"
         owner: "{{ aap_install_aap_user }}"
         group: "{{ aap_install_aap_group }}"
         mode: '0644'

--- a/rh-hashi/roles/aap_install/tasks/main.yml
+++ b/rh-hashi/roles/aap_install/tasks/main.yml
@@ -2,66 +2,68 @@
 
 - name: Create dir and copy over certs
   become: true
+  when: aap_install_provide_certs
   block:
 
     - name: Create storage directory for certificates
       ansible.builtin.file:
-        path: "{{ aap.certdir }}"
+        path: "{{ aap_install_cert_dir }}"
         mode: '0755'
-        owner: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        owner: "{{ aap_install_aap_user }}"
+        group: "{{ aap_install_aap_group }}"
         state: directory
 
     - name: Copy certs for this host
       ansible.builtin.copy:
-        src: "{{ local.certdir }}/"
-        dest: "{{ aap.certdir }}"
-        owner: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        src: "{{ aap_install_local_cert_dir }}/"
+        dest: "{{ aap_install_cert_dir }}"
+        owner: "{{ aap_install_aap_user }}"
+        group: "{{ aap_install_aap_group }}"
         mode: '0644'
 
-    - name: Copy ca cetificates to system trusted anchors
-      ansible.builtin.copy:
-        src: "{{ aap.certdir }}/{{ item }}"
-        dest: /etc/pki/ca-trust/source/anchors/root_2025-ca.pem
-        remote_src: true
-        owner: root
-        group: root
-        mode: '0644'
-      loop:
-        - root_2025-ca.crt
-        - intermediate.cert.pem
-      notify: Update system ssl trust db
+    # TODO this should not be necessary for the containerized installer
+    #- name: Copy ca cetificates to system trusted anchors
+    #  ansible.builtin.copy:
+    #    src: "{{ aap_install_cert_dir }}/{{ item }}"
+    #    dest: /etc/pki/ca-trust/source/anchors/root_2025-ca.pem
+    #    remote_src: true
+    #    owner: root
+    #    group: root
+    #    mode: '0644'
+    #  loop:
+    #    - root_2025-ca.crt
+    #    - intermediate.cert.pem
+    #  notify: Update system ssl trust db
 
-    - name: Flush handlers
-      ansible.builtin.meta: flush_handlers
+    #- name: Flush handlers
+    #  ansible.builtin.meta: flush_handlers
 
 - name: Install aap
   become: true
-  become_user: "{{ aap.user }}"
+  become_user: "{{ aap_install_aap_user }}"
   block:
 
     - name: Install aap containerized setup bundle to working dir
       ansible.builtin.copy:
-        src: "{{ aap.installer }}"
-        dest: "{{ aap.dir }}"
-        owner: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        src: "{{ aap_install_installer_bundle }}"
+        dest: "{{ aap_install_aap_user_dir }}"
+        owner: "{{ aap_install_aap_user }}"
+        group: "{{ aap_install_aap_group }}"
         mode: '0640'
 
     - name: Extract the containerized setup bundle
       ansible.builtin.unarchive:
-        src: "{{ aap.dir }}/{{ aap.installer }}"
-        dest: "{{ aap.dir }}"
+        src: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_bundle | basename }}"
+        dest: "{{ aap_install_aap_user_dir }}"
         remote_src: true
-        creates: "{{ aap.dir }}/{{ installer_extracted }}"
+        creates: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_dir }}"
 
     - name: Copy the templatized inventory to the created directory
       ansible.builtin.template:
         src: inventory-growth.j2
-        dest: "{{ aap.dir }}/{{ installer_extracted }}/inventory"
-        owner: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        dest: "{{ aap_install_aap_user_dir }}/{{ aap_install_installer_dir }}/inventory"
+        owner: "{{ aap_install_aap_user }}"
+        group: "{{ aap_install_aap_group }}"
         mode: '0644'
 
 #    - name: Setup directory to allow systemctl to be run via sudo

--- a/rh-hashi/roles/aap_install/templates/inventory-growth.j2
+++ b/rh-hashi/roles/aap_install/templates/inventory-growth.j2
@@ -39,9 +39,7 @@
 # This section is for the AAP database
 # -----------------------------------------------------
 [database]
-{% for host in groups['aap_hashi_aap'] %}
-{{ host }}
-{% endfor %}
+{{ groups['aap_hashi_aap'][0] }}
 
 [all:vars]
 # Ansible
@@ -51,81 +49,83 @@ ansible_connection=local
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 postgresql_admin_username=postgres
-postgresql_admin_password={{ aap.admin_pass }}
+postgresql_admin_password={{ aap_install_common_password }}
 
 bundle_install=true
 # The bundle directory must include /bundle in the path
 # bundle_dir='{{ lookup("ansible.builtin.env", "PWD") }}/bundle'
-bundle_dir='{{ aap.dir }}/{{ installer_extracted }}/bundle'
+bundle_dir='{{ aap_install_installer_dir }}/bundle'
 
 redis_mode=standalone
 
 # AAP Gateway
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
-gateway_admin_password={{ aap.admin_pass }}
+gateway_admin_password={{ aap_install_common_password }}
 gateway_pg_host={{ groups['aap_hashi_aap'][0] }}
-gateway_pg_password={{ aap.admin_pass }}
+gateway_pg_password={{ aap_install_common_password }}
 
 # AAP Controller
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables
 # -----------------------------------------------------
-controller_admin_password={{ aap.admin_pass }}
+controller_admin_password={{ aap_install_common_password }}
 controller_pg_host={{ groups['aap_hashi_aap'][0] }}
-controller_pg_password={{ aap.admin_pass }}
+controller_pg_password={{ aap_install_common_password }}
 controller_percent_memory_capacity=0.5
 
 # AAP Automation Hub
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-hub-variables
 # -----------------------------------------------------
-hub_admin_password={{ aap.admin_pass }}
+hub_admin_password={{ aap_install_common_password }}
 hub_pg_host={{ groups['aap_hashi_aap'][0] }}
-hub_pg_password={{ aap.admin_pass }}
+hub_pg_password={{ aap_install_common_password }}
 hub_seed_collections=false
 
 # AAP EDA Controller
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
-eda_admin_password={{ aap.admin_pass }}
+eda_admin_password={{ aap_install_common_password }}
 eda_pg_host={{ groups['aap_hashi_aap'][0] }}
-eda_pg_password={{ aap.admin_pass }}
+eda_pg_password={{ aap_install_common_password }}
+{% if aap_install_provide_certs %}
 
 # SSL Certificate Configuration
 
-custom_ca_cert={{ aap.certdir }}/intermediate.cert.pem
+custom_ca_cert={{ aap_install_custom_ca_cert }}
 
 # Platform gateway
-gateway_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-gateway_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-gateway_pg_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-gateway_pg_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-gateway_redis_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-gateway_redis_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+gateway_tls_cert={{ aap_install_common_cert }}
+gateway_tls_key={{ aap_install_common_key }}
+gateway_pg_tls_cert={{ aap_install_common_cert }}
+gateway_pg_tls_key={{ aap_install_common_key }}
+gateway_redis_tls_cert={{ aap_install_common_cert }}
+gateway_redis_tls_key={{ aap_install_common_key }}
 
 # Automation controller
-controller_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-controller_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-controller_pg_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-controller_pg_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+controller_tls_cert={{ aap_install_common_cert }}
+controller_tls_key={{ aap_install_common_key }}
+controller_pg_tls_cert={{ aap_install_common_cert }}
+controller_pg_tls_key={{ aap_install_common_key }}
 
 # Automation hub
-hub_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-hub_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-hub_pg_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-hub_pg_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+hub_tls_cert={{ aap_install_common_cert }}
+hub_tls_key={{ aap_install_common_key }}
+hub_pg_tls_cert={{ aap_install_common_cert }}
+hub_pg_tls_key={{ aap_install_common_key }}
 
 # Event-Driven Ansible
-eda_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-eda_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-eda_pg_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-eda_pg_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
-eda_redis_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-eda_redis_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+eda_tls_cert={{ aap_install_common_cert }}
+eda_tls_key={{ aap_install_common_key }}
+eda_pg_tls_cert={{ aap_install_common_cert }}
+eda_pg_tls_key={{ aap_install_common_key }}
+eda_redis_tls_cert={{ aap_install_common_cert }}
+eda_redis_tls_key={{ aap_install_common_key }}
 
 # PostgreSQL
-postgresql_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-postgresql_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+postgresql_tls_cert={{ aap_install_common_cert }}
+postgresql_tls_key={{ aap_install_common_key }}
 
 # Receptor
-# receptor_tls_cert={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.crt
-# receptor_tls_key={{ aap.certdir }}/{{ inventory_hostname_short }}.{{ vault.resource_name }}-server.key
+# receptor_tls_cert={{ aap_install_common_cert }}
+# receptor_tls_key={{ aap_install_common_key }}
+{% endif %}

--- a/rh-hashi/roles/aap_provision/defaults/main.yml
+++ b/rh-hashi/roles/aap_provision/defaults/main.yml
@@ -10,11 +10,6 @@ aap_provision_rhel_update: true
 # RHEL packages to install
 aap_provision_rhel_packages:
   - ansible-core
-#  - git-core
-#  - rsync
-#  - vim
-#  - wget
-#  - yum-utils
 
 # Local AAP service account for the containerized install
 aap_provision_aap_user: aap

--- a/rh-hashi/roles/aap_provision/defaults/main.yml
+++ b/rh-hashi/roles/aap_provision/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# RHEL subscription
+aap_provision_redhat_subscription: false
+aap_provision_redhat_username: ''
+aap_provision_redhat_password: ''
+
+# update RHEL packages to latest version
+aap_provision_rhel_update: true
+
+# RHEL packages to install
+aap_provision_rhel_packages:
+  - ansible-core
+#  - git-core
+#  - rsync
+#  - vim
+#  - wget
+#  - yum-utils
+
+# Local AAP service account for the containerized install
+aap_provision_aap_user: aap
+aap_provision_aap_group: aap
+
+...

--- a/rh-hashi/roles/aap_provision/tasks/main.yml
+++ b/rh-hashi/roles/aap_provision/tasks/main.yml
@@ -7,9 +7,10 @@
     - name: Register subscription for host with Red Hat
       community.general.redhat_subscription:
         state: present
-        username: "{{ sub.uid }}"
-        password: "{{ sub.pass }}"
+        username: "{{ aap_provision_redhat_username }}"
+        password: "{{ aap_provision_redhat_password }}"
         auto_attach: true
+      when: aap_provision_redhat_subscription
 
     - name: Update all packages on system to current
       ansible.builtin.package:
@@ -19,61 +20,37 @@
           - rhel-9-for-x86_64-appstream-rpms
         name: '*'
         state: latest
-
-    - name: Download repo keys and packages
-      ansible.builtin.get_url:
-        url: "{{ item }}"
-        dest: /tmp
-        mode: '0644'
-      loop:
-        - "{{ epel_package }}"
-
-    - name: Install EPEL repo gpg key
-      ansible.builtin.rpm_key:
-        key: "{{ epel_gpg_key }}"
-        state: present
-
-    - name: Install EPEL repo package
-      ansible.builtin.dnf:
-        name: "/tmp/{{ epel_package | regex_replace('.*/', '') }}"
-        state: present
+      when: aap_provision_rhel_update
 
     - name: Install package dependencies
       ansible.builtin.dnf:
-        name:
-          - ansible-core
-          - git-core
-          - rsync
-          - vim
-          - wget
-          - yum-utils
+        name: "{{ aap_provision_rhel_packages }}"
         state: present
 
-    - name: Create aap.group group
+    - name: Create local AAP service account group
       ansible.builtin.group:
-        name: "{{ aap.group }}"
+        name: "{{ aap_provision_aap_group }}"
         state: present
 
-    - name: Create user and group for aap to run under
+    - name: Create local AAP service account user
       ansible.builtin.user:
-        name: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        name: "{{ aap_provision_aap_user }}"
+        group: "{{ aap_provision_aap_group }}"
         system: true
 
-    - name: Add aap user to group wheel
+    - name: Add local AAP service account user to group wheel
       ansible.builtin.user:
-        name: "{{ aap.user }}"
+        name: "{{ aap_provision_aap_user }}"
         groups: wheel
         append: true
 
-    - name: Copy .ssh authorized keys from login user to ~aap
+    - name: Copy .ssh authorized keys from login user
       ansible.builtin.copy:
         src: /home/{{ ansible_user_id }}/.ssh/authorized_keys
-        dest: "~{{ aap.user }}/.ssh/"
+        dest: "~{{ aap_provision_aap_user }}/.ssh/"
         remote_src: true
-        owner: "{{ aap.user }}"
-        group: "{{ aap.group }}"
+        owner: "{{ aap_provision_aap_user }}"
+        group: "{{ aap_provision_aap_group }}"
         mode: '0644'
-
 
 ...


### PR DESCRIPTION
* New default variable names
* Relocated installation inventory template
* Added boolean toggle for user-provided certs
* Cert/key default to a common one used by all services since this is a containerized install.  Future work may mean adding service-specific variables as needed.
* Defaulted to a common admin password for the installer inventory.  Future work may mean additional variables needed for service-specific passwords.